### PR TITLE
Activity state indicators

### DIFF
--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -60,6 +60,7 @@ body
     #contextmenu.dropdown.clearfix(style="position: absolute; display: none")
         ul.dropdown-menu(role="menu" ara-labelledby="dropdownMenu" style="display: block; position: static; margin-bottom: 5px")
             li.dropdown-header.nodelabel
+            li.dropdown-header.activity
             li #[a.context-expand(href="#") Expand]
             li #[a.context-collapse(href="#") Collapse]
             li #[a.context-hide(href="#") Hide]

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -91,7 +91,10 @@ $(function () {
                 return d.data.usernames[0];
             },
             fill: function (d) {
-                return colormap((d.data || {}).type || "no type");
+                // Red for inactive users (e.g., mentioned by others only),
+                // purple for active users with non-geolocated tweets, and blue
+                // for active users with geolocated tweets.
+                return !d.data.active ? "#ca0020" : (d.data.geolocated ? "#0571b0" : "#7b3294");
             },
             nodeRadius: function (d, r) {
                 return d.data && d.data.grouped ? 2*r : r;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -151,8 +151,7 @@ $(function () {
                     left = getMenuPosition(d3.event.clientX, "width", "scrollLeft");
                     top = getMenuPosition(d3.event.clientY, "height", "scrollTop");
 
-                    cm.select("ul")
-                        .select("li.nodelabel")
+                    ul.select("li.nodelabel")
                         .text(function () {
                             var label = d.data.usernames[0];
 
@@ -161,6 +160,17 @@ $(function () {
                             }
 
                             return label;
+                        });
+
+                    ul.select("li.activity")
+                        .text(function () {
+                            if (!d.data.active) {
+                                return "(This user has sent no messages and was only mentioned by someone else.)";
+                            } else if (d.data.geolocated) {
+                                return "(This user has sent at least one geolocated message.)";
+                            } else {
+                                return "(This user has sent only sent non-geolocated messages.)";
+                            }
                         });
 
                     ul.select("a.context-hide")


### PR DESCRIPTION
- "Activity state" of a user can be
  - _Inactive_ - has not sent any messages; has only been mentioned by another user
  - _Non-geolocated_ - has sent messages, but none that are geolocated
  - _Geolocated_ - has sent messages, at least one of which is geolocated
- States are encoded once via color: inactive is red, non-geolocated is purple, and geolocated is blue
- States are encoded again redundantly via text description in the context menu
